### PR TITLE
Spelling mistake fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -19,11 +19,12 @@ A description of what you expected to happen.
 If applicable, add console output to help explain your problem.
 
 **Environment Information:**
- - z/OS Version: [e.g. 3.1]
- - Python Version: [e.g. IBM Python 3.13]
- - Is R_Admin _(IRRSEQ00)_ setup?
- - Is R_SecMgtOper _(IRRSMO00)_ setup?
- - Is all of the latest z/OS Language Environment service installed?
+
+- z/OS Version: [e.g. 3.1]
+- Python Version: [e.g. IBM Python 3.13]
+- Is R_Admin _(IRRSEQ00)_ setup?
+- Is R_SecMgtOper _(IRRSMO00)_ setup?
+- Is all of the latest z/OS Language Environment service installed?
 
 **Additional context**
 Add any other context about the problem here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,6 @@ The main way to test SEAR is to write **unit tests** in the [`tests`](tests) dir
 * **Unit Tests**
 
   > :bulb: _See the [Unity Unit Testing For C](https://www.throwtheswitch.org/unity) documentation for more details on writing test cases._
-
   > :white_check_mark: _In order to facilitate development and unit testing, the real **API calls** to **IRRSMO00** and **IRRSEQ00** have been mocked in [`tests/mock`](tests/mock). Additionally, implementations of some **z/OS specific C/C++ Runtime Library functions** are provided in [`tests/zoslib`](tests/zoslib) to enable the SEAR unit test suite to more or less be run on any 64-bit POSIX system where the `clang` compiler is installed. This ensures that development and testing can be done when contributors do not have access to a z/OS system, and also enables faster iteration since contributors can just run `make test` on their workstation without needing to copy the files to a z/OS system to run the unit tests._
 
   * Unit tests should be placed in the **subdirectory** corresponding to the **RACF callable service** you are creating a test for. The main focus of these tests is to validate the **generation of requests** to and **parsing of responses** from the **IRRSMO00** and **IRRSEQ00** callable services, and more generally testing various other code paths in the SEAR code. There are directories called `request_samples` and `response_samples` in the [`tests/irrseq00`](tests/irrseq00) and [`tests/irrsmo00`](tests/irrseq00) test folders to put request and response samples. All **raw request samples** and **raw response samples** for a given callable service should end with the `.bin` file extension. `get_raw_sample()` and `get_json_sample()` are defined in [`tests/unit_test_utilities.hpp`](tests/unit_test_utilities.hpp) to facilitate the loading of request and response samples in test cases. Other categories of test cases and test utilities must follow the same conventions described here.
@@ -77,7 +76,7 @@ The main way to test SEAR is to write **unit tests** in the [`tests`](tests) dir
 * **Functional Verification Tests**
   > :warning: _Ensure that the `SEAR_FVT_USERID` environment variable is set to a z/OS userid that doesn't exist on the system where the functional verifification tests are being run prior to running `make fvt`._
 
-  * In order to ensure that the real API calls to **IRRSEQ00** and **IRRSMO00** are working, build and install the Python distribution of SEAR from your branch/fork on a z/OS system and run `make fvt`. 
+  * In order to ensure that the real API calls to **IRRSEQ00** and **IRRSMO00** are working, build and install the Python distribution of SEAR from your branch/fork on a z/OS system and run `make fvt`.
 
 ### Fixing Bugs
 
@@ -91,10 +90,10 @@ If any updates need to be made to the SEAR documentation, open a GitHub pull req
 
 Code branches should use the following naming conventions:
 
-* `wip/name` *(Work in progress branch that likely won't be finished soon)*
-* `feat/name` *(Branch where new functionality or enhancements are being developed)*
-* `bug/name` *(Branch where one or more bugs are being fixed)*
-* `junk/name` *(Throwaway branch created for experimentation)*
+* `wip/name` _(Work in progress branch that likely won't be finished soon)_
+* `feat/name` _(Branch where new functionality or enhancements are being developed)_
+* `bug/name` _(Branch where one or more bugs are being fixed)_
+* `junk/name` _(Throwaway branch created for experimentation)_
 
 ## Style Guidelines
 
@@ -104,11 +103,11 @@ The use of the `clang-format` code formatter is required.
 
 The following code style conventions should be followed:
 
-* Variable names should use snake case *(i.e., `my_variable`)*.
-* Pointer variables should start with `p_` *(i.e., `p_my_pointer`)*.
-* Class variables should end with an `_` to help differentiate between class variables and local function variables *(i.e., `my_class_variable_`)*.
-* Class name should use pascal case *(i.e., `MyClass`)*.
-* Function names should use camel case *(i.e., `myFunction()`)*.
+* Variable names should use snake case _(i.e., `my_variable`)_.
+* Pointer variables should start with `p_` _(i.e., `p_my_pointer`)_.
+* Class variables should end with an `_` to help differentiate between class variables and local function variables _(i.e., `my_class_variable_`)_.
+* Class name should use pascal case _(i.e., `MyClass`)_.
+* Function names should use camel case _(i.e., `myFunction()`)_.
 * When calling a class function within the same class that function is a member of, the following syntax should be used to make it clear that a function within the same class is being called.
 
   ```cpp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thank you for taking the time to contribute to SEAR!
 The following are a set of guidelines to help you contribute.
 
-**Table Of Contents**
+## Table Of Contents
 
 * [Before Getting Started](#before-getting-started)
 
@@ -46,6 +46,7 @@ There are many ways to contribute to the project. You can write code, work on th
 If you want to write code, a good way to get started is by looking at the issues section of this repository. Look for the **Good First Issue** tag. Good First Issues are great as a first contribution.
 
 ### pre-commit Hooks
+
 To ensure `clang-format`, `cppcheck`, and **unit tests** are always run against your code on **every commit**, set up the **pre-commit hooks**.
 
 * Install [`pre-commit`](https://pre-commit.com/).
@@ -57,7 +58,7 @@ To ensure `clang-format`, `cppcheck`, and **unit tests** are always run against 
 
 ### Adding New Functionality
 
-If you want to continube new functionality, open a GitHub pull request against the `dev` branch with your changes. In the PR, make sure to clearly document the new functionality including why it is valuable.
+If you want to contribute new functionality, open a GitHub pull request against the `dev` branch with your changes. In the PR, make sure to clearly document the new functionality including why it is valuable.
 
 ### Testing
 
@@ -69,7 +70,7 @@ The main way to test SEAR is to write **unit tests** in the [`tests`](tests) dir
 
   > :white_check_mark: _In order to facilitate development and unit testing, the real **API calls** to **IRRSMO00** and **IRRSEQ00** have been mocked in [`tests/mock`](tests/mock). Additionally, implementations of some **z/OS specific C/C++ Runtime Library functions** are provided in [`tests/zoslib`](tests/zoslib) to enable the SEAR unit test suite to more or less be run on any 64-bit POSIX system where the `clang` compiler is installed. This ensures that development and testing can be done when contributors do not have access to a z/OS system, and also enables faster iteration since contributors can just run `make test` on their workstation without needing to copy the files to a z/OS system to run the unit tests._
 
-  * Unit tests should be placed in the **subdirectory** corresponding to the **RACF callable service** you are creating a test for. The main focus of these tests is to validate the **generation of requests** to and **parsing of responses** from the **IRRSMO00** and **IRRSEQ00** callable services, and more genenerally testing various other code paths in the SEAR code. There are directories called `request_samples` and `response_samples` in the [`tests/irrseq00`](tests/irrseq00) and [`tests/irrsmo00`](tests/irrseq00) test folders to put request and response samples. All **raw request samples** and **raw response samples** for a given callable service should end with the `.bin` file extension. `get_raw_sample()` and `get_json_sample()` are defined in [`tests/unit_test_utilities.hpp`](tests/unit_test_utilities.hpp) to facilitate the loading of request and response samples in test cases. Other categories of test cases and test utilities must follow the same conventions described here.
+  * Unit tests should be placed in the **subdirectory** corresponding to the **RACF callable service** you are creating a test for. The main focus of these tests is to validate the **generation of requests** to and **parsing of responses** from the **IRRSMO00** and **IRRSEQ00** callable services, and more generally testing various other code paths in the SEAR code. There are directories called `request_samples` and `response_samples` in the [`tests/irrseq00`](tests/irrseq00) and [`tests/irrsmo00`](tests/irrseq00) test folders to put request and response samples. All **raw request samples** and **raw response samples** for a given callable service should end with the `.bin` file extension. `get_raw_sample()` and `get_json_sample()` are defined in [`tests/unit_test_utilities.hpp`](tests/unit_test_utilities.hpp) to facilitate the loading of request and response samples in test cases. Other categories of test cases and test utilities must follow the same conventions described here.
 
     > _**Example:** A test case for verifying that SEAR can parse the result of an **extract user request** should be placed in the [`test_irrseq00.cpp`](tests/irrseq00/test_irrseq00.cpp) unit test module within the [`irrseq00`](tests/irrseq00) subdirectory. A **JSON request** sample containing the parameters for a **profile extract request** should be created in the [`irrseq00/request_samples/user`](tests/irrseq00/request_samples/user) directory. A **raw response** sample that contains the **mocked** result of the profile extract request and the corresponding expected **post-processed JSON response** should be created in the [`irrseq00/result_samples/user`](tests/irrseq00/result_samples/user) directory. Request/response samples should be loaded in the unit test case using the `get_raw_sample()` and `get_json_sample()` functions defined in [`tests/unit_test_utilities.hpp`](tests/unit_test_utilities.hpp). [`tests/unit_test_utilities.hpp`](tests/unit_test_utilities.hpp) also provides various other utility functions for facilitating the creation of test cases that should be used when applicable. [`irrseq00.hpp`](tests/mock/irrseq00.hpp) and [`irrsmo64.hpp`](tests/mock/irrsmo64.hpp) provide all of the necessary **global varibales** for mocking the result of requests made to `callRadmin()` and `IRRSMO64()` respectively._
 
@@ -102,7 +103,8 @@ Code branches should use the following naming conventions:
 The use of the `clang-format` code formatter is required.
 
 The following code style conventions should be followed:
-* Varible names should use snake case *(i.e., `my_variable`)*.
+
+* Variable names should use snake case *(i.e., `my_variable`)*.
 * Pointer variables should start with `p_` *(i.e., `p_my_pointer`)*.
 * Class variables should end with an `_` to help differentiate between class variables and local function variables *(i.e., `my_class_variable_`)*.
 * Class name should use pascal case *(i.e., `MyClass`)*.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ All versions of **z/OS** and the **IBM Open Enterprise SDK for Python** that are
 ### Dependencies
 
 * **R_SecMgtOper (IRRSMO00)**: Security Management Operations.
-  * More details about the authorizations required for **IRRSMO00** can be found [here](https://www.ibm.com/docs/en/zos/latest?topic=operations-racf-authorization).
+  * More details about the authorizations required for **IRRSMO00** can be found [in the IBM documentation](https://www.ibm.com/docs/en/zos/latest?topic=operations-racf-authorization).
 * **R_Admin (IRRSEQ00)**: RACF Administration API.
-  * More details about the authorizations required for **IRRSEQ00** can be found [here](https://www.ibm.com/docs/en/zos/latest?topic=api-racf-authorization).
+  * More details about the authorizations required for **IRRSEQ00** can be found [in the IBM documentation](https://www.ibm.com/docs/en/zos/latest?topic=api-racf-authorization).
 * **RACF Subsystem Address Space**: This is a dependency for both **IRRSMO00** and **IRRSEQ00**.
   * More information can be found [in the IBM documentation](https://www.ibm.com/docs/en/zos/latest?topic=considerations-racf-subsystem).
 * **z/OS Language Environment Runtime Support**: _SEAR_ is compiled using the **IBM Open XL C/C++ 2.1** compiler, which is still fairly new and requires **z/OS Language Environment** service updates for runtime support.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,3 @@
+# Security policy
+
 To report a security vulenaribily, use the [Report a vulnerability](https://github.com/Mainframe-Renewal-Project/sear/security/advisories/new) feature in GitHub.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
 # Security policy
 
-To report a security vulenaribily, use the [Report a vulnerability](https://github.com/Mainframe-Renewal-Project/sear/security/advisories/new) feature in GitHub.
+To report a security vulnerability, use the [Report a vulnerability](https://github.com/Mainframe-Renewal-Project/sear/security/advisories/new) feature in GitHub.

--- a/dev_tools/README.md
+++ b/dev_tools/README.md
@@ -1,6 +1,6 @@
-## Description
+# Description
 
-This is a folder where we store tools that were useful for the development of SEAR but do not hold any meaninful code. The files and their natures are explained below in sections based on the purpose of the file.
+This is a folder where we store tools that were useful for the development of SEAR but do not hold any meaningful code. The files and their natures are explained below in sections based on the purpose of the file.
 
 ## Unit Test Generation/Conversion
 

--- a/dev_tools/generate_doc_tables.py
+++ b/dev_tools/generate_doc_tables.py
@@ -73,11 +73,11 @@ def convert_key_map_hpp_to_doc(input_filepath, output_filepath):
     header_file_data = f.read()
     f.close()
 
-    segement_trait_information = header_file_data.split('segment_key_mapping_t')[0]
+    segment_trait_information = header_file_data.split('segment_key_mapping_t')[0]
 
     segment_mapping = f"{admin_type.replace(" ","_").upper()}_([A-Z]*)(?<!SEGMENT)_(?:SEGMENT|KEY)_MAP"
 
-    segments = re.findall(segment_mapping, segement_trait_information)
+    segments = re.findall(segment_mapping, segment_trait_information)
     
     for segment in segments:
         if segment.upper() == "CSDATA":
@@ -87,7 +87,7 @@ def convert_key_map_hpp_to_doc(input_filepath, output_filepath):
         "| **Trait** | **RACF Key** | **Data Types** | **Operators Allowed** | **Supported Operations** |\n"
         trait_mapping = f"\"({segment.lower()}:[a-z_]*)\"," + \
         ".*\"([a-z]*)\",\n.*TRAIT_TYPE_([A-Z]*),.*\\{(true|false), (true|false), (true|false), (true|false)\\}"
-        traits = re.findall(trait_mapping, segement_trait_information)
+        traits = re.findall(trait_mapping, segment_trait_information)
         for trait in traits:
             #print(trait)
             operators_allowed = []

--- a/dev_tools/map_fields.py
+++ b/dev_tools/map_fields.py
@@ -305,7 +305,7 @@ valid_segment_traits["p_admin"] = {
                 "cdtinfo:generic_profile_sharing": "genlist",
                 "cdtinfo:grouping_class_name": "grouping",
                 "cdtinfo:key_qualifiers": "keyqual",
-                "cdtinfo:manditory_access_control_processing": "macprocessing",
+                "cdtinfo:mandatory_access_control_processing": "macprocessing",
                 "cdtinfo:max_length": "maxlenx",
                 "cdtinfo:max_length_entityx": "maxlength",
                 "cdtinfo:member_class_name": "member",
@@ -356,7 +356,7 @@ valid_segment_traits["p_admin"] = {
                 "icsf:symmetric_export_public_keys": "symexportkey",
                 "icsf:symmetric_cpacf_rewrap": "symcpacfwrap",
                 "icsf:symmetric_cpacf_rewrap_return": "symcpacfret",
-                "icsf:asymetric_key_usage": "asymusage",
+                "icsf:asymmetric_key_usage": "asymusage",
             },
             "ictx": {
                 "ictx:use_identity_map": "domap",

--- a/sear/key_map/key_map_group_connection.hpp
+++ b/sear/key_map/key_map_group_connection.hpp
@@ -27,7 +27,7 @@ const trait_key_mapping_t GROUP_CONNECTION_BASE_SEGMENT_MAP[]{
      TRAIT_TYPE_UINT, {false, false, false, false},
      },
     {
-     "base:connecion_last_used_date", "cgljdate",
+     "base:connection_last_used_date", "cgljdate",
      TRAIT_TYPE_STRING, {false, false, false, false},
      },
     {


### PR DESCRIPTION
This should fix the following bugs:
https://github.com/Mainframe-Renewal-Project/sear/issues/53
https://github.com/Mainframe-Renewal-Project/sear/issues/52
https://github.com/Mainframe-Renewal-Project/sear/issues/51

It also comes with a ton of fixes for spelling mistakes in issue templates, markdown files, and a few variables.