### PR TITLE
Fix logo url for PyPi page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![SEAR Logo](https://github.com/Mainframe-Renewal-Project/sear/blob/main/logo.svg)
+![SEAR Logo](https://raw.githubusercontent.com/Mainframe-Renewal-Project/sear/refs/heads/main/logo.svg)
 
 A standardized JSON interface for RACF that enables seamless exploitation by programming languages that have a foreign language interface for C/C++ and native JSON support.
 


### PR DESCRIPTION
Forgot to give readme the raw link for the logo, breaking it on PyPi
