### PR TITLE
Fixed the reverted build system not naming the wheel correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,18 +120,12 @@ def main():
                 extra_objects=[f"{assembled_object_path}"],
             ),
         ],
-        "cmdclass": {"build_ext": BuildExtensionWithAssemblerAndC},
+        "cmdclass": {
+            "build_ext": BuildExtensionWithAssemblerAndC,
+            "bdist_wheel": bdist_wheel,
+            },
     }
     setup(**setup_args)
-
-    setup(
-        name='pysear',
-        cmdclass={
-            'build_ext': main,
-            "bdist_wheel": bdist_wheel,
-        },
-    )
-
 
 if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,6 @@ from setuptools.command.build_ext import build_ext
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
 
-class CExtension(Extension):
-    def __init__(self, name):
-        # don't invoke the original build_ext for this special extension
-        super().__init__(name, sources=[])
-
 class bdist_wheel(_bdist_wheel): # noqa: N801
     def finalize_options(self):
         super().finalize_options()
@@ -127,14 +122,8 @@ def main():
         ],
         "cmdclass": {"build_ext": BuildExtensionWithAssemblerAndC},
     }
-    setup(
-    name='pysear',
-    ext_modules=[CExtension('sear._C')],
-    cmdclass={
-        'build_ext': build_ext,
-        "bdist_wheel": bdist_wheel,
-    },
-)
+    setup(**setup_args)
+
 
 if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -124,6 +124,14 @@ def main():
     }
     setup(**setup_args)
 
+    setup(
+        name='pysear',
+        cmdclass={
+            'build_ext': main,
+            "bdist_wheel": bdist_wheel,
+        },
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,15 @@ from pathlib import Path
 
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
+
+class bdist_wheel(_bdist_wheel): # noqa: N801
+    def finalize_options(self):
+        super().finalize_options()
+
+        # marks built wheels as 'none-any' to allow installation on non-z/OS systems
+        self.root_is_pure = True
 
 def assemble(asm_file: str, asm_directory: Path) -> None:
     """Assemble assembler code."""
@@ -114,8 +122,13 @@ def main():
         ],
         "cmdclass": {"build_ext": BuildExtensionWithAssemblerAndC},
     }
-    setup(**setup_args)
-
+    setup(
+    name='pysear',
+    cmdclass={
+        'build_ext': build_ext,
+        "bdist_wheel": bdist_wheel,
+    },
+)
 
 if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,11 @@ from setuptools.command.build_ext import build_ext
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
 
+class CExtension(Extension):
+    def __init__(self, name):
+        # don't invoke the original build_ext for this special extension
+        super().__init__(name, sources=[])
+
 class bdist_wheel(_bdist_wheel): # noqa: N801
     def finalize_options(self):
         super().finalize_options()
@@ -124,6 +129,7 @@ def main():
     }
     setup(
     name='pysear',
+    ext_modules=[CExtension('sear._C')],
     cmdclass={
         'build_ext': build_ext,
         "bdist_wheel": bdist_wheel,


### PR DESCRIPTION
Fixed the reverted build system not naming the wheel correctly. The way it named the file resulted in PyPi rejecting it and preventing us from releasing Alpha 2.1. Tested that it works