### PR TITLE
Labeler can now add the tests "tag" to pull requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,6 +12,11 @@ build:
     - any-glob-to-any-file: 'CMakePresets.json'
     - any-glob-to-any-file: 'Makefile'
 
+tests:
+  - changed-files:
+    - any-glob-to-any-file: 'tests/**'
+    - any-glob-to-any-file: 'python_tests/**'
+
 python:
   - changed-files:
     - any-glob-to-any-file: 'python/**.py'


### PR DESCRIPTION
Labeler can now add the tests "tag" to pull requests if people update things in tests/ or python_tests/