### PR TITLE
Make the traits section optional for connects

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -227,8 +227,7 @@
         "operation",
         "admin_type",
         "userid",
-        "group",
-        "traits"
+        "group"
       ],
       "additionalProperties": false
     },


### PR DESCRIPTION
I made the "traits" section in group connects optional, so you don't have to do an empty traits section if you want a connect that uses defaults.

Before:
```python
connect_result = sear(
        {
        "operation": "alter", 
        "admin_type": "group-connection", 
        "userid": "USER",
        "group": "TESTGRP",
        "traits": {

        },
        },
    )
```
Now:
```python
connect_result = sear(
        {
        "operation": "alter", 
        "admin_type": "group-connection", 
        "userid": "USER",
        "group": "TESTGRP",
        },
    )
```