### PR TITLE
Made traits optional for more situations

### DIFF
--- a/python_tests/test_dataset.py
+++ b/python_tests/test_dataset.py
@@ -20,6 +20,18 @@ def test_add_dataset(delete_dataset):
     assert "errors" not in str(add_result.result)
     assert add_result.result["return_codes"] == successful_return_codes
 
+def test_add_dataset_no_traits(delete_dataset):
+    """This test is supposed to succeed"""
+    add_result = sear(
+            {
+            "operation": "add", 
+            "admin_type": "dataset", 
+            "dataset": delete_dataset,
+            },
+        )
+    assert "errors" not in str(add_result.result)
+    assert add_result.result["return_codes"] == successful_return_codes
+
 def test_add_dataset_missing_dataset():
     """This test is supposed to fail"""
     add_result = sear(

--- a/python_tests/test_group.py
+++ b/python_tests/test_group.py
@@ -20,6 +20,18 @@ def test_add_group(delete_group):
     assert "errors" not in str(add_result.result)
     assert add_result.result["return_codes"] == successful_return_codes
 
+def test_add_group_no_traits(delete_group):
+    """This test is supposed to succeed"""
+    add_result = sear(
+            {
+            "operation": "add", 
+            "admin_type": "group", 
+            "group": delete_group,
+            },
+        )
+    assert "errors" not in str(add_result.result)
+    assert add_result.result["return_codes"] == successful_return_codes
+
 def test_extract_group(create_group):
     """This test is supposed to succeed"""
     extract_result = sear(

--- a/python_tests/test_resource.py
+++ b/python_tests/test_resource.py
@@ -21,6 +21,19 @@ def test_add_resource_profile(delete_resource):
         )
     assert add_result.result["return_codes"] == successful_return_codes
 
+def test_add_resource_profile_no_traits(delete_resource):
+    """This test is supposed to succeed"""
+    profile_name, class_name = delete_resource
+    add_result = sear(
+            {
+            "operation": "add", 
+            "admin_type": "resource", 
+            "resource": profile_name,
+            "class": class_name,
+            },
+        )
+    assert add_result.result["return_codes"] == successful_return_codes
+
 def test_extract_resource_profile(create_resource):
     """This test is supposed to succeed"""
     profile_name, class_name = create_resource

--- a/python_tests/test_user.py
+++ b/python_tests/test_user.py
@@ -38,6 +38,18 @@ def test_add_user_base_traits(delete_user):
     assert "errors" not in str(add_result.result)
     assert add_result.result["return_codes"] == successful_return_codes
 
+def test_add_user_no_traits(delete_user):
+    """This test is supposed to succeed"""
+    add_result = sear(
+            {
+            "operation": "add", 
+            "admin_type": "user", 
+            "userid": delete_user,
+            },
+        )
+    assert "errors" not in str(add_result.result)
+    assert add_result.result["return_codes"] == successful_return_codes
+
 def test_add_user_tso_traits(delete_user):
     """This test is supposed to succeed"""
     add_result = sear(

--- a/schema.json
+++ b/schema.json
@@ -44,7 +44,33 @@
       "properties": {
         "operation": {
           "enum": [
-            "add",
+            "add"
+          ]
+        },
+        "admin_type": {
+          "const": "user"
+        },
+        "userid": {
+          "$ref": "#/$defs/eightCharacterString"
+        },
+        "traits": {
+          "type": "object"
+        },
+        "run_as_userid": {
+          "$ref": "#/$defs/eightCharacterString"
+        }
+      },
+      "required": [
+        "operation",
+        "admin_type",
+        "userid"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "operation": {
+          "enum": [
             "alter"
           ]
         },
@@ -332,7 +358,37 @@
       "properties": {
         "operation": {
           "enum": [
-            "add",
+            "add"
+          ]
+        },
+        "admin_type": {
+          "const": "resource"
+        },
+        "resource": {
+          "$ref": "#/$defs/resourceName"
+        },
+        "class": {
+          "$ref": "#/$defs/eightCharacterString"
+        },
+        "traits": {
+          "type": "object"
+        },
+        "run_as_userid": {
+          "$ref": "#/$defs/eightCharacterString"
+        }
+      },
+      "required": [
+        "operation",
+        "admin_type",
+        "resource",
+        "class"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "operation": {
+          "enum": [
             "alter"
           ]
         },

--- a/schema.json
+++ b/schema.json
@@ -428,7 +428,39 @@
       "properties": {
         "operation": {
           "enum": [
-            "add",
+            "add"
+          ]
+        },
+        "admin_type": {
+          "const": "dataset"
+        },
+        "dataset": {
+          "$ref": "#/$defs/dataSetName"
+        },
+        "volume": {
+          "$ref": "#/$defs/volumeSerial"
+        },
+        "generic": {
+          "type": "boolean"
+        },
+        "traits": {
+          "type": "object"
+        },
+        "run_as_userid": {
+          "$ref": "#/$defs/eightCharacterString"
+        }
+      },
+      "required": [
+        "operation",
+        "admin_type",
+        "dataset"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "operation": {
+          "enum": [
             "alter"
           ]
         },

--- a/schema.json
+++ b/schema.json
@@ -132,7 +132,33 @@
       "properties": {
         "operation": {
           "enum": [
-            "add",
+            "add"
+          ]
+        },
+        "admin_type": {
+          "const": "group"
+        },
+        "group": {
+          "$ref": "#/$defs/eightCharacterString"
+        },
+        "traits": {
+          "type": "object"
+        },
+        "run_as_userid": {
+          "$ref": "#/$defs/eightCharacterString"
+        }
+      },
+      "required": [
+        "operation",
+        "admin_type",
+        "group"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "operation": {
+          "enum": [
             "alter"
           ]
         },


### PR DESCRIPTION
Made the "traits" section optional for the add operation for everything except permits. Also added CI/CD tests to ensure this works as a supported feature.