### PR TITLE
Fixed Python builds (finally)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,14 @@ from pathlib import Path
 
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
+
+class bdist_wheel(_bdist_wheel): # noqa: N801
+    def finalize_options(self):
+        super().finalize_options()
+
+        self.plat_name = "os390"
 
 def assemble(asm_file: str, asm_directory: Path) -> None:
     """Assemble assembler code."""
@@ -114,6 +121,7 @@ def main():
         ],
         "cmdclass": {
             "build_ext": BuildExtensionWithAssemblerAndC,
+            "bdist_wheel": bdist_wheel,
             },
     }
     setup(**setup_args)

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 import json
 import os
 import subprocess
+import sys
 from glob import glob
 from pathlib import Path
 
@@ -16,6 +17,7 @@ class bdist_wheel(_bdist_wheel): # noqa: N801
         super().finalize_options()
 
         self.root_is_pure = True
+        self.python_tag = f"py{sys.version_info.major}{sys.version_info.minor}"
 
 def assemble(asm_file: str, asm_directory: Path) -> None:
     """Assemble assembler code."""

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ class bdist_wheel(_bdist_wheel): # noqa: N801
     def finalize_options(self):
         super().finalize_options()
 
-        self.plat_name = "os390"
+        self.root_is_pure = True
 
 def assemble(asm_file: str, asm_directory: Path) -> None:
     """Assemble assembler code."""


### PR DESCRIPTION
Due to a bug in the z/OS implementation of Python we have to avoid putting platform tags on our packages, even though that is not best practice. Our build system as of 0.3.0 will now build two Python packages fixing a bug reported by the community with 0.2.1 not working for Python 3.12
