### PR TITLE
Fixed incorrect branch name in Ruff workflow

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,9 +1,9 @@
 name: Ruff
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
There was a bug in the Ruff workflow, instead of "main" it said "push" under branches.