### PR TITLE
Renamed changed outmessage2 and inmessage2 to temporary

### DIFF
--- a/sear/irrseq00/profile_post_processor.cpp
+++ b/sear/irrseq00/profile_post_processor.cpp
@@ -291,8 +291,8 @@ void ProfilePostProcessor::postProcessRACFRRSF(SecurityRequest &request) {
       ProfilePostProcessor::postprocessRRSFOffsetField(node_definition, "base:in_message_dataset_name", p_profile, p_nodes->offset_inmsg_dataset_name);
       ProfilePostProcessor::postprocessRRSFOffsetField(node_definition, "base:out_message_dataset_name", p_profile, p_nodes->offset_outmsg_dataset_name);
 
-      ProfilePostProcessor::postprocessRRSFOffsetField(node_definition, "base:temporary_in_message_dataset_name", p_profile, p_nodes->offset_inmsg_dataset_name);
-      ProfilePostProcessor::postprocessRRSFOffsetField(node_definition, "base:temporary_out_message_dataset_name", p_profile, p_nodes->offset_outmsg_dataset_name);
+      ProfilePostProcessor::postprocessRRSFOffsetField(node_definition, "base:temporary_in_message_dataset_name", p_profile, p_nodes->offset_inmsg2_dataset_name);
+      ProfilePostProcessor::postprocessRRSFOffsetField(node_definition, "base:temporary_out_message_dataset_name", p_profile, p_nodes->offset_outmsg2_dataset_name);
 
       node_definition["base:in_message_records"] = p_nodes->inmsg_records;
       node_definition["base:out_message_records"] = p_nodes->outmsg_records;


### PR DESCRIPTION
Renamed changed out_message2 and in_message2 to temporary_in_message, to make the naming conventions more in line with the rest of the API.