### PR TITLE
RRSF bit flags fix

### DIFF
--- a/sear/irrseq00/profile_post_processor.cpp
+++ b/sear/irrseq00/profile_post_processor.cpp
@@ -360,7 +360,7 @@ void ProfilePostProcessor::postProcessRACFRRSF(SecurityRequest &request) {
   }
 
   // Checks if user is authorized to query RRSF settings
-  if (ntohl(rrsf_extract_result->bit_flags) & ~RRSF_NOT_AUTHORIZED_TARGET_LIST) {
+  if (ntohl(rrsf_extract_result->bit_flags) & ~RRSF_NOT_AUTHORIZED_SET_LIST && ntohl(rrsf_extract_result->bit_flags) & ~RRSF_NOT_AUTHORIZED_TARGET_LIST) {
     if (ntohl(rrsf_extract_result->bit_flags) & RRSF_FULLRRSFCOMM_ACTIVE) {
       profile["profile"]["base"]["base:full_rrsf_communication_active"] = true;
     } else {


### PR DESCRIPTION
Fixes bug that resulted in around 9 RRSF trait values being returned as false if multiple of them were true at the same time.