### PR TITLE
Fix Precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,11 @@ repos:
     hooks:
       - id: cppcheck
         name: cppcheck
-        entry: make check
+        entry: | 
+          bash -c '
+            cmake --preset linux-test
+            cmake --build --preset linux-test --target check
+          '
         language: system
         pass_filenames: false
         always_run: true
@@ -17,7 +21,13 @@ repos:
     hooks:
       - id: unit-test
         name: unit-test
-        entry: make test
+        entry: | 
+          bash -c '
+            cmake --preset linux-test -DBUILD_SHARED_LIBS=on
+            cmake --build --preset linux-test --target sear
+            cmake --build --preset linux-test --target test_runner
+            ./build/linux/test_runner
+          '
         language: system
         pass_filenames: false
         always_run: true

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ TESTS			= ${PWD}/tests
 ZOSLIB			= $(TESTS)/zoslib
 
 CSTANDARD		= c99
-CXXSTANDARD		= c++14
+CXXSTANDARD		= c++17
 
 COMMON_INC		= \
 				-I $(SRC) \
@@ -28,8 +28,8 @@ COMMON_INC		= \
 				-I $(KEY_MAP) \
 				-I $(VALIDATION) \
 				-I $(JSON) \
-				-I $(JSON_SCHEMA)
-				-I $(ICONV) \
+				-I $(JSON_SCHEMA) \
+				-I $(ICONV)
 
 # JSON Schemas
 SEAR_SCHEMA	= $(shell cat ${PWD}/schema.json | jq -c)
@@ -68,7 +68,7 @@ else ifeq ($(UNAME), Darwin)
 	CC			= clang
 	CXX			= clang++
 
-	SRCZOSLIB	= $(ZOSLIB)/*.c
+	SRCZOSLIB	= $(ZOSLIB)/*.cpp
 
 	CFLAGS		= \
 				-std=$(CXXSTANDARD) -D__ptr32= \
@@ -88,7 +88,7 @@ else
 	CC			= clang
 	CXX			= clang++
 
-	SRCZOSLIB	= $(ZOSLIB)/*.c
+	SRCZOSLIB	= $(ZOSLIB)/*.cpp
 
 	CFLAGS		= \
 				-std=$(CXXSTANDARD) -D__ptr32= \


### PR DESCRIPTION
## Description
This PR addresses the local build and pre-commit failures identified in #188. 

By updating the C++ standard and refining the source file paths, this ensures that the project can be built and tested locally on Linux environments.

## Changes
- **Makefile:** Fixed a syntax error in `COMMON_INC`.
- **Makefile:** Updated `CXXSTANDARD` from `c++14` to `c++17` to support `std::string_view`.
- **Makefile:** Corrected `SRCZOSLIB` pathing to prevent `clang++` errors when `.c` files are missing in the test directory.

## Testing Performed
- Ran `make test` on Linux (Clang++).
- Verified that `conversion.hpp` now compiles correctly with `std::string_view`.
- Confirmed `pre-commit` hooks now pass the `unit-test` and `cppcheck` stages.

fix #188 
