### PR TITLE
Add dev-build workflow

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,0 +1,81 @@
+name: Dev Build and Test
+
+on:
+  push:
+    branches:
+      - dev
+    pull_request:
+      branches:
+        - dev
+
+permissions:
+  contents: read
+  
+jobs:
+  build-dev:
+    runs-on: ubuntu-latest
+
+    environment:
+      name: development
+
+    steps:
+      - name: Set Timestamp
+        id: vars
+        run: echo "ts=$(date +'%Y%m%d%H%M')" >> $GITHUB_OUTPUT
+
+      - name: Build package
+        run: |
+            mkdir ~/.ssh
+            echo "${{ secrets.SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+            echo "${{ secrets.BUILD_USER_PRIVATE_KEY }}" > private_key
+            chmod 500 private_key
+            ssh ${{ secrets.BUILD_SSH_CONNECTION }} -i private_key
+      - name: Download manifest
+        run: |
+            scp -B -q -i private_key ${{ secrets.BUILD_SCP_CONNECTION }}:"files.txt" .
+            echo "Found build artifacts:"
+            cat files.txt         
+      - name: Download package
+        run: |
+            mkdir dist
+            while IFS= read -r file; do
+                echo "Downloading file: $file"
+                scp -B -q -i private_key ${{ secrets.BUILD_SCP_CONNECTION }}:"$file" dist/
+            done < files.txt
+      - name: Upload Dev Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-dist-${{ steps.vars.outputs.ts }}
+          path: dist/*
+
+  test-dev:
+    runs-on: ubuntu-latest
+    needs:
+      - build-dev
+
+    environment:
+      name: test
+
+    steps:
+      - name: Retrieve test distributions
+        uses: actions/download-artifact@v4
+        with:
+            name: dev-dist-${{ steps.vars.outputs.ts }}
+            path: dist/
+
+      - name: Upload package
+        run: |
+            mkdir ~/.ssh
+            echo "${{ secrets.SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+            echo "${{ secrets.TEST_USER_PRIVATE_KEY }}" > private_key
+            chmod 500 private_key
+            scp -B -q -i private_key ${{ secrets.TEST_SCP_ARGS }} dist/*.whl ${{ secrets.TEST_SCP_CONNECTION }}:artifacts/
+
+      - name: Run test
+        run: |
+            ssh ${{ secrets.TEST_SSH_CONNECTION }} -i private_key
+
+      - name: Download report
+        if: always()
+        run: |
+            scp -B -q -i private_key ${{ secrets.TEST_SCP_ARGS }} ${{ secrets.TEST_SCP_CONNECTION }}:"report.md" $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Following up on issue #143, I have added a new GitHub Action workflow to handle development builds and testing. This allows the team to verify code on the z/OS build environment and retrieve artifacts without triggering a full production release.

## Changes
- **New Workflow:** Added `.github/workflows/dev-build.yml`.
- **Logic:** Mirrors the production SSH/SCP-based build/test logic but is scoped to the `dev` branch and the `development` environment.
- **Artifact Management:** Implemented a timestamped artifact naming convention (`dev-dists-${{ timestamp }}`) to ensure developers can track specific build iterations.
- **Reporting:** Configured the workflow to download and display the `report.md` in the GitHub Step Summary for immediate feedback.

## Why this approach?
By utilizing the existing SSH/SCP mechanism, we maintain parity with the production environment (ensuring z/OS compatibility) while isolating development artifacts from production releases.
