### PR TITLE
Ignore error codes 4,4,4 for search requests

### DIFF
--- a/sear/irrseq00/profile_extractor.cpp
+++ b/sear/irrseq00/profile_extractor.cpp
@@ -249,7 +249,6 @@ void ProfileExtractor::extract(SecurityRequest &request) {
       request.setSEARReturnCode(0);
       request.setRawResultLength(0);
       request.setRawRequestPointer(nullptr);
-      return;
     } else {
       if (request.getSAFReturnCode() != 0 || request.getRACFReturnCode() != 0 ||
         request.getRACFReasonCode() != 0 || rc != 0 ||


### PR DESCRIPTION
When doing a search that results in error codes 4,4,4 it no longer results in a hard error, addresses a few edge cases such as classes with no profiles and I believe also discrete profiles tagged as generic. The if checks might be able to be simplified. This addresses issue #179.