### PR TITLE
Update pre-commit hook to ensure clean build environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
         name: unit-test
         entry: | 
           bash -c '
+            rm -rf build/linux
             cmake --preset linux-test -DBUILD_SHARED_LIBS=on
             cmake --build --preset linux-test --target sear
             cmake --build --preset linux-test --target test_runner

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
         name: cppcheck
         entry: | 
           bash -c '
+            rm -rf build/linux
             cmake --preset linux-test
             cmake --build --preset linux-test --target check
           '


### PR DESCRIPTION
**Description**
This PR updates the `.pre-commit-config.yaml` to include a manual cache cleanup (`rm -rf build/linux`) before running unit tests.

As discovered in #198, the CMake cache was occasionally persisting old binary logic (specifically the RACF 4,4,4 return code handling), leading to "false pass" scenarios locally that failed on GitHub Actions.

Related Issues
Ref: #198 (Inconsistency between RACF 4,4,4 logic and Mock Data)