### PR TITLE
Fixed compiler error from new pugixml functionality

### DIFF
--- a/sear/irrsmo00/xml_generator.hpp
+++ b/sear/irrsmo00/xml_generator.hpp
@@ -4,6 +4,7 @@
 #include <nlohmann/json.hpp>
 #include <pugixml.hpp>
 #include <string>
+#include <sstream>
 
 #include "logger.hpp"
 #include "security_request.hpp"


### PR DESCRIPTION
A small bug slipped past that prevented compilation from Python with the new pugixml functionality, error:
```
sear/irrsmo00/xml_generator.cpp:66:21: error: implicit instantiation of undefined template 'std::basic_stringstream<char>'
   66 |   std::stringstream ss;
      |                     ^
/usr/lpp/IBM/cnw/v2r1/openxl/bin/../include/c++/v1/__fwd/sstream.h:29:28: note: template is declared here
   29 | class _LIBCPP_TEMPLATE_VIS basic_stringstream;
      |                            ^
1 error generated.
error: command '/usr/lpp/IBM/cnw/v2r1/openxl/bin/ibm-clang++64' failed with exit code 1
```