### PR TITLE
Fix Labeler to match everything in sear

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -23,7 +23,7 @@ build:
 
 core:
   - changed-files:
-    - any-glob-to-any-file: 'sear/**'
+    - any-glob-to-any-file: 'sear/**/*'
     - any-glob-to-any-file: 'schema.json'
 
 tests:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -28,7 +28,7 @@ core:
 
 tests:
   - changed-files:
-    - any-glob-to-any-file: 'tests/**'
+    - any-glob-to-any-file: 'tests/**/*'
     - any-glob-to-any-file: 'python_tests/**'
     - any-glob-to-any-file: 'lua_tests/**'
     - any-glob-to-any-file: 'go_tests/**'


### PR DESCRIPTION
This PR updates the **Labeler** configuration to properly catch files nested deep within the `sear/` directory structure.

The previous pattern (`sear/**`) was failing to trigger labels for changes in sub-folders like `sear/irrsmo00/`. Changing this to `sear/**/*` ensures the glob expands recursively to all files at any depth.
