### PR TITLE
Bugfix: Align unit test mocks and normalize EXTRACT-NEXT return codes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,35 +4,39 @@ documentation:
 
 meta:
   - changed-files:
-    - any-glob-to-any-file: '.github/ISSUE_TEMPLATE/**'
-    - any-glob-to-any-file: '.vscode/**'
-    - any-glob-to-any-file: '.github/labeler.yml'
-    - any-glob-to-any-file: '.github/PULL_REQUEST_TEMPLATE.md'
-    - any-glob-to-any-file: 'logo.svg'
+    - any-glob-to-any-file:
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.vscode/**'
+      - '.github/labeler.yml'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - 'logo.svg'
 
 build:
   - changed-files:
-    - any-glob-to-any-file: 'pyproject.toml'
-    - any-glob-to-any-file: 'setup.py'
-    - any-glob-to-any-file: .github/workflows/**
-    - any-glob-to-any-file: 'cmake/**'
-    - any-glob-to-any-file: '**.cmake'
-    - any-glob-to-any-file: 'CMakeLists.txt'
-    - any-glob-to-any-file: 'CMakePresets.json'
-    - any-glob-to-any-file: 'Makefile'
+    - any-glob-to-any-file:
+      - 'pyproject.toml'
+      - 'setup.py'
+      - '.github/workflows/**'
+      - 'cmake/**'
+      - '**.cmake'
+      - 'CMakeLists.txt'
+      - 'CMakePresets.json'
+      - 'Makefile'
 
 core:
   - changed-files:
-    - any-glob-to-any-file: 'sear/**/*'
-    - any-glob-to-any-file: 'schema.json'
+    - any-glob-to-any-file:
+      - 'sear/**/*'
+      - 'schema.json'
 
 tests:
   - changed-files:
-    - any-glob-to-any-file: 'tests/**/*'
-    - any-glob-to-any-file: 'python_tests/**'
-    - any-glob-to-any-file: 'lua_tests/**'
-    - any-glob-to-any-file: 'go_tests/**'
-    - any-glob-to-any-file: 'java_tests/**'
+    - any-glob-to-any-file:
+      - 'tests/**/*'
+      - 'python_tests/**'
+      - 'lua_tests/**'
+      - 'go_tests/**'
+      - 'java_tests/**'
 
 python:
   - changed-files:

--- a/sear/irrseq00/profile_extractor.cpp
+++ b/sear/irrseq00/profile_extractor.cpp
@@ -1,9 +1,10 @@
 #include "profile_extractor.hpp"
 
+#include <stdio.h>
+
 #include <algorithm>
 #include <cctype>
 #include <cstdio>
-#include <stdio.h>
 #include <cstdlib>
 #include <cstring>
 #include <memory>
@@ -88,7 +89,7 @@ void ProfileExtractor::extract(SecurityRequest &request) {
     // Preserve Return & Reason Codes
     request.setSAFReturnCode(ntohl(p_arg_area->args.SAF_rc));
     request.setRACFReturnCode(ntohl(p_arg_area->args.RACF_rc));
-    request.setRACFReasonCode(ntohl(p_arg_area->args.RACF_rsn));  
+    request.setRACFReasonCode(ntohl(p_arg_area->args.RACF_rsn));
   }
   /***************************************************************************/
   /* Generic Extract                                                         */
@@ -99,7 +100,7 @@ void ProfileExtractor::extract(SecurityRequest &request) {
   /*   - Group Connection Extract                                            */
   /*   - Resource Extract                                                    */
   /*   - Data Set Extract                                                    */
-  /***************************************************************************/  
+  /***************************************************************************/
   else {
     // Build 31-bit Arg Area
     auto unique_ptr = make_unique31<generic_extract_underbar_arg_area_t>();
@@ -155,12 +156,11 @@ void ProfileExtractor::extract(SecurityRequest &request) {
 
       if (function_code == DATASET_EXTRACT_NEXT_FUNCTION_CODE) {
         p_arg_area->arg_pointers.p_profile_extract_parms->flags |=
-          htonl(0x14000000);
+            htonl(0x14000000);
       } else {
         p_arg_area->arg_pointers.p_profile_extract_parms->flags =
-          htonl(0x04000000);
+            htonl(0x04000000);
       }
-
 
       // Call R_Admin
       Logger::getInstance().debug("Calling IRRSEQ00 ...");
@@ -182,10 +182,10 @@ void ProfileExtractor::extract(SecurityRequest &request) {
 
       if (function_code == DATASET_EXTRACT_NEXT_FUNCTION_CODE) {
         p_arg_area->arg_pointers.p_profile_extract_parms->flags |=
-          htonl(0x14000000);
+            htonl(0x14000000);
       } else {
         p_arg_area->arg_pointers.p_profile_extract_parms->flags =
-          htonl(0x04000000);
+            htonl(0x04000000);
       }
 
       do {
@@ -240,6 +240,14 @@ void ProfileExtractor::extract(SecurityRequest &request) {
           reinterpret_cast<char *>(p_save_generic_result);
     }
 
+    // If the loop found at least one profile, we treat the overall
+    // operation as a success (0,0,0) even though the last call was 4,4,4.
+    if (!request.getFoundProfiles().empty()) {
+      p_arg_area->args.SAF_rc   = 0;
+      p_arg_area->args.RACF_rc  = 0;
+      p_arg_area->args.RACF_rsn = 0;
+    }
+
     request.setRawResultPointer(p_arg_area->args.p_result_buffer);
     // Preserve Return & Reason Codes
     request.setSAFReturnCode(ntohl(p_arg_area->args.SAF_rc));
@@ -255,21 +263,21 @@ void ProfileExtractor::extract(SecurityRequest &request) {
     // Ignore error codes when SAF returns error codes 4,4,4
     // Since that combination means no profiles found
     if (request.getSAFReturnCode() == 4 && request.getRACFReturnCode() == 4 &&
-        request.getRACFReasonCode() == 4 ) {
-      
+        request.getRACFReasonCode() == 4) {
       request.setSEARReturnCode(0);
       request.setRawResultLength(0);
       request.setRawRequestPointer(nullptr);
+      return;
     } else {
       if (request.getSAFReturnCode() != 0 || request.getRACFReturnCode() != 0 ||
-        request.getRACFReasonCode() != 0 || rc != 0 ||
-        request.getRawResultPointer() == nullptr) {
+          request.getRACFReasonCode() != 0 || rc != 0 ||
+          request.getRawResultPointer() == nullptr) {
         request.setSEARReturnCode(4);
         // Raise Exception if Search Failed.
         const std::string &admin_type = request.getAdminType();
         throw SEARError("unable to search '" + admin_type + "' profile '" +
-                        request.getProfileName() + "'");     
-      } 
+                        request.getProfileName() + "'");
+      }
     }
   } else {
     if (request.getSAFReturnCode() != 0 || request.getRACFReturnCode() != 0 ||
@@ -307,7 +315,7 @@ void ProfileExtractor::extract(SecurityRequest &request) {
   if (request.getAdminType() == "racf-rrsf") {
     const racf_rrsf_extract_results_t *p_rrsf_result =
         reinterpret_cast<const racf_rrsf_extract_results_t *>(p_raw_result);
-    raw_result_length = ntohl(p_rrsf_result->result_buffer_length);    
+    raw_result_length = ntohl(p_rrsf_result->result_buffer_length);
   } else if (request.getAdminType() == "racf-options") {
     const racf_options_extract_results_t *p_setropts_result =
         reinterpret_cast<const racf_options_extract_results_t *>(p_raw_result);

--- a/tests/irrseq00/result_samples/dataset/test_extract_next_dataset_empty_result.json
+++ b/tests/irrseq00/result_samples/dataset/test_extract_next_dataset_empty_result.json
@@ -1,0 +1,1 @@
+{"profiles":[],"return_codes":{"racf_reason_code":4,"racf_return_code":4,"saf_return_code":4,"sear_return_code":0}}

--- a/tests/irrseq00/result_samples/dataset/test_extract_next_dataset_result.json
+++ b/tests/irrseq00/result_samples/dataset/test_extract_next_dataset_result.json
@@ -1,1 +1,1 @@
-{"profiles":["Z23I.**"],"return_codes":{"racf_reason_code":4,"racf_return_code":4,"saf_return_code":4,"sear_return_code":0}}
+{"profiles":["Z23I.**"],"return_codes":{"racf_reason_code":0,"racf_return_code":0,"saf_return_code":0,"sear_return_code":0}}

--- a/tests/irrseq00/result_samples/group/test_extract_next_group_empty_result.json
+++ b/tests/irrseq00/result_samples/group/test_extract_next_group_empty_result.json
@@ -1,0 +1,1 @@
+{"profiles":[],"return_codes":{"racf_reason_code":4,"racf_return_code":4,"saf_return_code":4,"sear_return_code":0}}

--- a/tests/irrseq00/result_samples/group/test_extract_next_group_result.json
+++ b/tests/irrseq00/result_samples/group/test_extract_next_group_result.json
@@ -1,1 +1,1 @@
-{"profiles":["Z23I"],"return_codes":{"racf_reason_code":4,"racf_return_code":4,"saf_return_code":4,"sear_return_code":0}}
+{"profiles":["Z23I"],"return_codes":{"racf_reason_code":0,"racf_return_code":0,"saf_return_code":0,"sear_return_code":0}}

--- a/tests/irrseq00/result_samples/resource/test_extract_next_resource_empty_result.json
+++ b/tests/irrseq00/result_samples/resource/test_extract_next_resource_empty_result.json
@@ -1,0 +1,1 @@
+{"profiles":[],"return_codes":{"racf_reason_code":4,"racf_return_code":4,"saf_return_code":4,"sear_return_code":0}}

--- a/tests/irrseq00/result_samples/resource/test_extract_next_resource_result.json
+++ b/tests/irrseq00/result_samples/resource/test_extract_next_resource_result.json
@@ -1,1 +1,1 @@
-{"profiles":["**"],"return_codes":{"racf_reason_code":4,"racf_return_code":4,"saf_return_code":4,"sear_return_code":0}}
+{"profiles":["**"],"return_codes":{"racf_reason_code":0,"racf_return_code":0,"saf_return_code":0,"sear_return_code":0}}

--- a/tests/irrseq00/result_samples/user/test_extract_next_user_empty_result.json
+++ b/tests/irrseq00/result_samples/user/test_extract_next_user_empty_result.json
@@ -1,0 +1,1 @@
+{ "profiles": [], "return_codes": { "racf_reason_code": 4, "racf_return_code": 4, "saf_return_code": 4, "sear_return_code": 0 } }

--- a/tests/irrseq00/result_samples/user/test_extract_next_user_result.json
+++ b/tests/irrseq00/result_samples/user/test_extract_next_user_result.json
@@ -1,1 +1,1 @@
-{ "profiles": [ "ZWESVUSR" ], "return_codes": { "racf_reason_code": 4, "racf_return_code": 4, "saf_return_code": 4, "sear_return_code": 0 } }
+{ "profiles": [ "ZWESVUSR" ], "return_codes": { "racf_reason_code": 0, "racf_return_code": 0, "saf_return_code": 0, "sear_return_code": 0 } }

--- a/tests/irrseq00/test_irrseq00.cpp
+++ b/tests/irrseq00/test_irrseq00.cpp
@@ -69,6 +69,12 @@ void test_parse_extract_next_user_result() {
                                  TEST_EXTRACT_NEXT_USER_RESULT_RAW, false);
 }
 
+void test_parse_extract_next_user_empty_result() {
+  test_parse_extract_next_empty_result(TEST_EXTRACT_NEXT_USER_REQUEST_JSON,
+                                       TEST_EXTRACT_NEXT_USER_RESULT_EMPTY_JSON,
+                                       false);
+}
+
 /*************************************************************************/
 /* Group                                                                 */
 /*************************************************************************/
@@ -117,6 +123,12 @@ void test_parse_extract_next_group_result() {
   test_parse_extract_next_result(TEST_EXTRACT_NEXT_GROUP_REQUEST_JSON,
                                  TEST_EXTRACT_NEXT_GROUP_RESULT_JSON,
                                  TEST_EXTRACT_NEXT_GROUP_RESULT_RAW, false);
+}
+
+void test_parse_extract_next_group_empty_result() {
+  test_parse_extract_next_empty_result(
+      TEST_EXTRACT_NEXT_GROUP_REQUEST_JSON,
+      TEST_EXTRACT_NEXT_GROUP_RESULT_EMPTY_JSON, false);
 }
 
 /*************************************************************************/
@@ -233,6 +245,12 @@ void test_parse_extract_next_dataset_result() {
                                  TEST_EXTRACT_NEXT_DATASET_RESULT_RAW, false);
 }
 
+void test_parse_extract_next_dataset_empty_result() {
+  test_parse_extract_next_empty_result(
+      TEST_EXTRACT_NEXT_DATASET_REQUEST_JSON,
+      TEST_EXTRACT_NEXT_DATASET_RESULT_EMPTY_JSON, false);
+}
+
 /*************************************************************************/
 /* Resource                                                              */
 /*************************************************************************/
@@ -288,4 +306,10 @@ void test_parse_extract_next_resource_result() {
   test_parse_extract_next_result(TEST_EXTRACT_NEXT_RESOURCE_REQUEST_JSON,
                                  TEST_EXTRACT_NEXT_RESOURCE_RESULT_JSON,
                                  TEST_EXTRACT_NEXT_RESOURCE_RESULT_RAW, false);
+}
+
+void test_parse_extract_next_resource_empty_result() {
+  test_parse_extract_next_empty_result(
+      TEST_EXTRACT_NEXT_RESOURCE_REQUEST_JSON,
+      TEST_EXTRACT_NEXT_RESOURCE_RESULT_EMPTY_JSON, false);
 }

--- a/tests/irrseq00/test_irrseq00.hpp
+++ b/tests/irrseq00/test_irrseq00.hpp
@@ -132,6 +132,8 @@
 
 #define TEST_EXTRACT_NEXT_USER_RESULT_JSON \
   IRRSEQ00_RESULT_SAMPLES "user/test_extract_next_user_result.json"
+#define TEST_EXTRACT_NEXT_USER_RESULT_EMPTY_JSON \
+  IRRSEQ00_RESULT_SAMPLES "user/test_extract_next_user_empty_result.json"
 #define TEST_EXTRACT_NEXT_USER_RESULT_RAW \
   IRRSEQ00_RESULT_SAMPLES "user/test_extract_next_user_result.bin"
 
@@ -150,6 +152,8 @@
 
 #define TEST_EXTRACT_NEXT_GROUP_RESULT_JSON \
   IRRSEQ00_RESULT_SAMPLES "group/test_extract_next_group_result.json"
+#define TEST_EXTRACT_NEXT_GROUP_RESULT_EMPTY_JSON \
+  IRRSEQ00_RESULT_SAMPLES "group/test_extract_next_group_empty_result.json"
 #define TEST_EXTRACT_NEXT_GROUP_RESULT_RAW \
   IRRSEQ00_RESULT_SAMPLES "group/test_extract_next_group_result.bin"
 
@@ -189,6 +193,9 @@
 
 #define TEST_EXTRACT_NEXT_DATASET_RESULT_JSON \
   IRRSEQ00_RESULT_SAMPLES "dataset/test_extract_next_dataset_result.json"
+#define TEST_EXTRACT_NEXT_DATASET_RESULT_EMPTY_JSON \
+  IRRSEQ00_RESULT_SAMPLES                           \
+  "dataset/test_extract_next_dataset_empty_result.json"
 #define TEST_EXTRACT_NEXT_DATASET_RESULT_RAW \
   IRRSEQ00_RESULT_SAMPLES "dataset/test_extract_next_dataset_result.bin"
 
@@ -207,6 +214,9 @@
 
 #define TEST_EXTRACT_NEXT_RESOURCE_RESULT_JSON \
   IRRSEQ00_RESULT_SAMPLES "resource/test_extract_next_resource_result.json"
+#define TEST_EXTRACT_NEXT_RESOURCE_RESULT_EMPTY_JSON \
+  IRRSEQ00_RESULT_SAMPLES                            \
+  "resource/test_extract_next_resource_empty_result.json"
 #define TEST_EXTRACT_NEXT_RESOURCE_RESULT_RAW \
   IRRSEQ00_RESULT_SAMPLES "resource/test_extract_next_resource_result.bin"
 
@@ -225,6 +235,7 @@ void test_parse_extract_user_result_pseudo_boolean();
 
 void test_generate_extract_next_user_request();
 void test_parse_extract_next_user_result();
+void test_parse_extract_next_user_empty_result();
 
 // Group
 void test_generate_extract_group_request();
@@ -236,6 +247,7 @@ void test_parse_extract_group_result_extraneous_parameter_provided();
 
 void test_generate_extract_next_group_request();
 void test_parse_extract_next_group_result();
+void test_parse_extract_next_group_empty_result();
 
 // Group Connection
 void test_generate_extract_group_connection_request();
@@ -260,6 +272,7 @@ void test_parse_extract_dataset_result_extraneous_parameter_provided();
 
 void test_generate_extract_next_dataset_request();
 void test_parse_extract_next_dataset_result();
+void test_parse_extract_next_dataset_empty_result();
 
 // Resource
 void test_generate_extract_resource_request();
@@ -272,5 +285,6 @@ void test_parse_extract_resource_result_extraneous_parameter_provided();
 
 void test_generate_extract_next_resource_request();
 void test_parse_extract_next_resource_result();
+void test_parse_extract_next_resource_empty_result();
 
 #endif

--- a/tests/test_runner.cpp
+++ b/tests/test_runner.cpp
@@ -118,6 +118,7 @@ int main() {
 
   RUN_TEST(test_generate_extract_next_user_request);
   RUN_TEST(test_parse_extract_next_user_result);
+  RUN_TEST(test_parse_extract_next_user_empty_result);
 
   // Group
   RUN_TEST(test_generate_extract_group_request);
@@ -129,6 +130,7 @@ int main() {
 
   RUN_TEST(test_generate_extract_next_group_request);
   RUN_TEST(test_parse_extract_next_group_result);
+  RUN_TEST(test_parse_extract_next_group_empty_result);
 
   // Group Connection
   RUN_TEST(test_generate_extract_group_connection_request);
@@ -155,6 +157,7 @@ int main() {
 
   RUN_TEST(test_generate_extract_next_dataset_request);
   RUN_TEST(test_parse_extract_next_dataset_result);
+  RUN_TEST(test_parse_extract_next_dataset_empty_result);
 
   // Resource
   RUN_TEST(test_generate_extract_resource_request);
@@ -168,6 +171,7 @@ int main() {
 
   RUN_TEST(test_generate_extract_next_resource_request);
   RUN_TEST(test_parse_extract_next_resource_result);
+  RUN_TEST(test_parse_extract_next_resource_empty_result);
 
   /*************************************************************************/
   /* IRRSDL00                                                              */

--- a/tests/unit_test_utilities.cpp
+++ b/tests/unit_test_utilities.cpp
@@ -207,6 +207,30 @@ void test_parse_extract_next_result(const char *test_extract_next_request_json,
   free(r_admin_result_mock);
 }
 
+void test_parse_extract_next_empty_result(
+    const char *test_extract_next_request_json,
+    const char *test_extract_next_result_json, bool debug) {
+  std::string request_json = get_json_sample(test_extract_next_request_json);
+  std::string result_json_expected =
+      get_json_sample(test_extract_next_result_json);
+
+  // Mock R_Admin result
+  r_admin_result_size_mock = 0;
+  r_admin_rc_mock          = 4;
+  r_admin_saf_rc_mock      = 4;
+  r_admin_racf_rc_mock     = 4;
+  r_admin_racf_reason_mock = 4;
+
+  sear_result_t *result =
+      sear(request_json.c_str(), request_json.length(), debug);
+
+  TEST_ASSERT_EQUAL_STRING(result_json_expected.c_str(), result->result_json);
+  TEST_ASSERT_EQUAL_INT32(result_json_expected.length(),
+                          result->result_json_length);
+  TEST_ASSERT_EQUAL_CHAR(0, result->result_json[result->result_json_length]);
+  TEST_ASSERT_EQUAL_INT32(r_admin_result_size_mock, result->raw_result_length);
+}
+
 void test_parse_extract_result_profile_not_found(
     const char *test_extract_request_json,
     const char *test_extract_result_profile_not_found_json, bool debug) {

--- a/tests/unit_test_utilities.hpp
+++ b/tests/unit_test_utilities.hpp
@@ -46,6 +46,9 @@ void test_parse_extract_next_result(const char *test_extract_next_request_json,
                                     const char *test_extract_next_result_json,
                                     const char *test_extract_next_result_raw,
                                     bool debug);
+void test_parse_extract_next_empty_result(
+    const char *test_extract_next_request_json,
+    const char *test_extract_next_result_json, bool debug);
 void test_parse_extract_result_profile_not_found(
     const char *test_extract_request_json,
     const char *test_extract_result_profile_not_found_json, bool debug);


### PR DESCRIPTION
## Description
This PR addresses a logic conflict where the RACF 4,4,4 return code (indicating "no more profiles authorized") was causing assertion failures in our unit tests. It also introduces a "Logical Success" override to ensure that if a request successfully retrieved profiles, the final status reported to the caller is 0,0,0.

```c++
if (request.getSAFReturnCode() == 4 && request.getRACFReturnCode() == 4 &&
        request.getRACFReasonCode() == 4) {
      request.setSEARReturnCode(0);
      request.setRawResultLength(0);
      request.setRawRequestPointer(nullptr);
      return;  // We can now return directly the function. 
                  // With 0,0,0 if at least one profile found, 4,4,4 if nothing found
}
```

## Changes
1. Success Masking for Found Profiles
Modified the operation handler to override the return codes. If the `found_profiles_` is not empty, the status is set to **0,0,0**, even if the final internal RACF call returned 4,4,4.

```C++
// If the loop found at least one profile, 
// we treat the overall operation as a success (0,0,0) even though the last call was 4,4,4.
if (!request.getFoundProfiles().empty()) {
    p_arg_area->args.SAF_rc   = 0;
    p_arg_area->args.RACF_rc  = 0;
    p_arg_area->args.RACF_rsn = 0;
}
```
2. Mock Data Correction
Updated existing JSON mock files (e.g., `test_extract_next_group_result.json`) to resolve the data contradiction.

The fix: Mocks containing 0,0,0 return codes now correctly return a list of profiles.

```json
{"profiles":["Z23I"],"return_codes":{"racf_reason_code":0,"racf_return_code":0,"saf_return_code":0,"sear_return_code":0}}
```

3. Expanded Test Suite
Introduced new unit test case:

`test_extract_next_group_empty_result.json`: Verifies that when 4,4,4 is returned, returns a length of 0 without triggering an assertion failure.

```json
{"profiles":[],"return_codes":{"racf_reason_code":4,"racf_return_code":4,"saf_return_code":4,"sear_return_code":0}}
```

Ref: #198 