### PR TITLE
Align Python Search Tests with search return codes

### DIFF
--- a/python_tests/helper.py
+++ b/python_tests/helper.py
@@ -40,7 +40,7 @@ group_not_found_return_codes = {
     "sear_return_code": 4,
   }
 
-successful_return_codes_search = {
+empty_return_codes_search = {
     "racf_reason_code": 4,
     "racf_return_code": 4,
     "saf_return_code": 4,

--- a/python_tests/test_search.py
+++ b/python_tests/test_search.py
@@ -1,5 +1,5 @@
 
-from helper import successful_return_codes, successful_return_codes_search
+from helper import successful_return_codes, empty_return_codes_search
 
 # Import SEAR
 from sear import sear
@@ -27,7 +27,7 @@ def test_search_resource_profiles_class_missing():
     assert search_result.result["return_codes"] != successful_return_codes
 
 def test_search_resource_profiles_nonexistent_class():
-    """This test is supposed to fail"""
+    """This test is supposed to succeed with empty result"""
     search_result = sear(
             {
             "operation": "search", 
@@ -35,8 +35,8 @@ def test_search_resource_profiles_nonexistent_class():
             "class": "WRONG", 
             },
         )
-    assert "errors" in str(search_result.result)
-    assert search_result.result["return_codes"] != successful_return_codes
+    assert "errors" not in str(search_result.result)
+    assert search_result.result["return_codes"] == empty_return_codes_search
 
 def test_search_resource_profiles_all():
     """This test is supposed to succeed"""
@@ -48,7 +48,7 @@ def test_search_resource_profiles_all():
             },
         )
     assert "errors" not in str(search_result.result)
-    assert search_result.result["return_codes"] == successful_return_codes_search
+    assert search_result.result["return_codes"] == successful_return_codes
 
 def test_search_resource_profiles_filter(create_resources_in_search_class):
     """This test is supposed to succeed"""
@@ -64,7 +64,7 @@ def test_search_resource_profiles_filter(create_resources_in_search_class):
     assert "errors" not in str(search_result.result)
     for profile in profiles:
         assert profile in search_result.result["profiles"]
-    assert search_result.result["return_codes"] == successful_return_codes_search
+    assert search_result.result["return_codes"] == successful_return_codes
 
 def test_search_resource_profiles_discrete(create_resource_in_search_class):
     """This test is supposed to succeed"""


### PR DESCRIPTION
### :bulb: Issue Reference

Ref #215 
Recreating PR to test new Benchmark Test.

### :computer: What does this address?

This PR updates the Python unit test suite to differentiate between a successful data retrieval (0,0,0,0) and a successful empty result (4,4,4,0).

Previously, all successful searches were asserting against a hardcoded 4,4,4 state. Following the core logic update, searches that return profiles now provide a standard success code.

### :pager: Implementation Details

Updated Assertions: Refactored `test_search_resource_profiles_nonexistent_class`, `test_search_resource_profiles_all` and `test_search_resource_profiles_filter` to use the correct return code constants based on whether profiles are expected.

* Use `successful_return_codes` when the result list contains profiles.
* Use `empty_return_codes_search` when the result list is empty.

Need to run the tests in zos before merging


