### PR TITLE
Added z/OS 3.2 functionality

### DIFF
--- a/sear/key_map/key_map_user.hpp
+++ b/sear/key_map/key_map_user.hpp
@@ -31,6 +31,22 @@ const trait_key_mapping_t USER_BASE_SEGMENT_MAP[]{
      TRAIT_TYPE_STRING,   {false, true, true, false},
      },
     {
+     "base:contain",    "contain",
+     TRAIT_TYPE_BOOLEAN, {false, false, true, true},
+     },
+    {
+     "base:never_contain",    "nevercon",
+     TRAIT_TYPE_BOOLEAN, {false, false, true, true},
+     },
+    {
+     "base:no_contain",    "nocontai",
+     TRAIT_TYPE_BOOLEAN, {false, true, true, false},
+     },
+    {
+     "base:allow_contain",    "allowcon",
+     TRAIT_TYPE_BOOLEAN, {false, false, true, true},
+     },
+    {
      "base:class_authorizations",    "clcnt",
      TRAIT_TYPE_REPEAT, {false, false, false, false},
      },

--- a/sear/key_map/key_map_user.hpp
+++ b/sear/key_map/key_map_user.hpp
@@ -31,22 +31,6 @@ const trait_key_mapping_t USER_BASE_SEGMENT_MAP[]{
      TRAIT_TYPE_STRING,   {false, true, true, false},
      },
     {
-     "base:contain",    "contain",
-     TRAIT_TYPE_BOOLEAN, {true, false, false, false},
-     },
-    {
-     "base:never_contain",    "nevercon",
-     TRAIT_TYPE_BOOLEAN, {true, false, false, false},
-     },
-    {
-     "base:no_contain",    "nocontai",
-     TRAIT_TYPE_BOOLEAN, {true, true, false, false},
-     },
-    {
-     "base:allow_contain",    "allowcon",
-     TRAIT_TYPE_BOOLEAN, {true, false, false, false},
-     },
-    {
      "base:class_authorizations",    "clcnt",
      TRAIT_TYPE_REPEAT, {false, false, false, false},
      },
@@ -293,6 +277,23 @@ const trait_key_mapping_t USER_BASE_SEGMENT_MAP[]{
     {
      "base:logon_allowed_time", "whentime",
      TRAIT_TYPE_STRING,  {true, false, false, false},
+     },
+    // z/OS 3.2 and later
+    {
+     "base:contain",    "contain",
+     TRAIT_TYPE_BOOLEAN, {true, false, false, false},
+     },
+    {
+     "base:never_contain",    "nevercon",
+     TRAIT_TYPE_BOOLEAN, {true, false, false, false},
+     },
+    {
+     "base:no_contain",    "nocontai",
+     TRAIT_TYPE_BOOLEAN, {true, true, false, false},
+     },
+    {
+     "base:allow_contain",    "allowcon",
+     TRAIT_TYPE_BOOLEAN, {true, false, false, false},
      }
 };
 

--- a/sear/key_map/key_map_user.hpp
+++ b/sear/key_map/key_map_user.hpp
@@ -32,19 +32,19 @@ const trait_key_mapping_t USER_BASE_SEGMENT_MAP[]{
      },
     {
      "base:contain",    "contain",
-     TRAIT_TYPE_BOOLEAN, {false, false, true, true},
+     TRAIT_TYPE_BOOLEAN, {true, false, false, false},
      },
     {
      "base:never_contain",    "nevercon",
-     TRAIT_TYPE_BOOLEAN, {false, false, true, true},
+     TRAIT_TYPE_BOOLEAN, {true, false, false, false},
      },
     {
      "base:no_contain",    "nocontai",
-     TRAIT_TYPE_BOOLEAN, {false, true, true, false},
+     TRAIT_TYPE_BOOLEAN, {true, true, false, false},
      },
     {
      "base:allow_contain",    "allowcon",
-     TRAIT_TYPE_BOOLEAN, {false, false, true, true},
+     TRAIT_TYPE_BOOLEAN, {true, false, false, false},
      },
     {
      "base:class_authorizations",    "clcnt",


### PR DESCRIPTION
z/OS 3.2 added a new contain option, it's basically a more aggressive revoke that also stops active SSH and TSO sessions (among other things). Shouldn't break support on older versions.