### PR TITLE
Dropped 3.12 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
     "Programming Language :: C++",
     'Programming Language :: Python',
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     'Programming Language :: Python :: 3 :: Only',


### PR DESCRIPTION
Dropped Python 3.12 support, since it's now considered EOL by IBM