### PR TITLE
Remove legacy encoding system

### DIFF
--- a/sear/irrseq00/profile_extractor.cpp
+++ b/sear/irrseq00/profile_extractor.cpp
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <string>
 
+#include "../conversion.hpp"
 #include "irrseq00.hpp"
 #include "sear_error.hpp"
 

--- a/sear/irrseq00/profile_extractor.cpp
+++ b/sear/irrseq00/profile_extractor.cpp
@@ -375,10 +375,13 @@ void ProfileExtractor::buildGenericExtractRequest(
 
     // Class name must be padded with blanks.
     std::memset(&profile_extract_parms->class_name, ' ', 8);
+
+    // Encode class name as IBM-1047.
+    class_name = fromUTF8(class_name);
+
     std::memcpy(profile_extract_parms->class_name, class_name.c_str(),
                 class_name.length());
-    // Encode class name as IBM-1047.
-    __a2e_l(profile_extract_parms->class_name, 8);
+
   }
   profile_extract_parms->profile_name_length = htonl(profile_name.length());
 

--- a/sear/irrseq00/profile_extractor.cpp
+++ b/sear/irrseq00/profile_extractor.cpp
@@ -361,9 +361,11 @@ void ProfileExtractor::buildGenericExtractRequest(
   std::transform(profile_name.begin(), profile_name.end(), profile_name.begin(),
                  [](unsigned char c) { return std::toupper(c); });
 
-  std::memcpy(args->profile_name, profile_name.c_str(), profile_name.length());
   // Encode profile name as IBM-1047.
-  __a2e_l(args->profile_name, profile_name.length());
+  profile_name = fromUTF8(profile_name);
+
+  std::memcpy(args->profile_name, profile_name.c_str(), profile_name.length());
+
   if (function_code == RESOURCE_EXTRACT_FUNCTION_CODE ||
       function_code == RESOURCE_EXTRACT_NEXT_FUNCTION_CODE) {
     // Automatically convert lowercase class names to uppercase.


### PR DESCRIPTION
There are still a few places in the codebase that uses a2e and e2a for encoding, instead of the UTF8 based encoding system added a few updates ago. This PR removes the last few instances from the IRRSEQ00 portion of the codebase, leaving only the old method in the keyring and certificate portions. The changes have been tested in the real world.