### PR TITLE
Fixed workflows being auto encoded on z/OS to iso8859-1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,5 +7,6 @@
 *.d.ts git-encoding=utf-8 zos-working-tree-encoding=utf-8
 *.cpp zos-working-tree-encoding=utf-8
 *.hpp zos-working-tree-encoding=utf-8
+.github/workflows/*.yml zos-working-tree-encoding=utf-8
 tests/validation/request_samples/test_syntax_error_binary_data_request.json binary
 README.md git-encoding=utf-8 zos-working-tree-encoding=utf-8 working-tree-encoding=utf-8 eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,6 @@
 *.d.ts git-encoding=utf-8 zos-working-tree-encoding=utf-8
 *.cpp zos-working-tree-encoding=utf-8
 *.hpp zos-working-tree-encoding=utf-8
-.github/workflows/*.yml zos-working-tree-encoding=utf-8
+*.yml zos-working-tree-encoding=utf-8
 tests/validation/request_samples/test_syntax_error_binary_data_request.json binary
 README.md git-encoding=utf-8 zos-working-tree-encoding=utf-8 working-tree-encoding=utf-8 eol=lf


### PR DESCRIPTION
Workflow files were being converted to iso8859-1 when there were emojis in them, this caused the build environment to become "dirty" which caused the build system to label production builds as dev builds (which then blocked release)